### PR TITLE
specfile: dependency afm-rpm-macros bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ A binding example for AGL, implemented in a redpesk® context
 
 To follow this tutorial without inconvenience, you have to get the following tools ready to use:
 
-* wget
+- wget
 
-* xz
+- xz
 
-* ssh
+- ssh
 
-* qemu (more details at a later stage)
+- qemu (more details at a later stage)
 
 Moreover, in order to use redpesk® services, you must register [here](https://auth.redpesk.bzh/dex/auth?client_id=redpesk&redirect_uri=http%3A%2F%2Fruntime.redpesk.iot%3A8000%2Foauth%2Fcallback&response_type=code&scope=openid+profile+email&state=jIfn4y6gTEG87Asvj2DAxcK2WJv63ASW) ! You can either create your own account, or use your GitHub one.
 
@@ -28,32 +28,32 @@ The agl-service-helloworld specfile can be found at the following path:
 [conf.d/packaging/agl-service-helloworld.spec](conf.d/packaging/agl-service-helloworld.spec).
 This specfile will be used by redpesk® to describe how to build your AGL application. The resulting build produces an AGL widget that is embedded in a RPM.
 Please read the [documentation](https://docs.redpesk.bzh/) to correctly create and set your redpesk® project and application set up.
-You may have noticed that the agl-service-helloworld specfile contained several afm rpm macros, such as `%afm_widget`.
+You may have noticed that the agl-service-helloworld specfile contained several afm rpm macros, such as `%afm_package`.
 These macros allow to define a specfile template for AGL application.
-For example the two following macros indicate that this package is composed by two sub-packages
+For example the three following macros indicate that this package is composed by three sub-packages
 
-* `%afm_package_widget`  &rarr; agl-service-helloworld-widget: which is basically the core widget
+- `%afm_package` &rarr; agl-service-helloworld: which is basically the core widget
 
-* `%afm_package_widget_test` &rarr; agl-service-helloworld-widget-test: which is a widget, implementing the tests used to validate the source code. Test source files are located in [test](test) directory
+- `%afm_package_test` &rarr; agl-service-helloworld-test: which is a widget, implementing the tests used to validate the source code. Test source files are located in [test](test) directory
 
-* `%afm_package_widget_redtest` &rarr; agl-service-helloworld-widget-redtest: this package is the one used by the RedPesk infrastructure to run the test. It requires the package agl-service-helloworld-widget-test where the tests truly are. In the case of agl binding test (this is the case here), this package only contains a script that calls the right command to run the agl tests. This script can be found in the [redtest](redtest) directory.
+- `%afm_package_redtest` &rarr; agl-service-helloworld-redtest: this package is the one used by the RedPesk infrastructure to run the test. It requires the package agl-service-helloworld-test where the tests truly are. In the case of agl binding test (this is the case here), this package only contains a script that calls the right command to run the agl tests. This script can be found in the [redtest](redtest) directory.
 
 ### Project configuration
 
 However, to fit the template introduced by afm rpm macros, your project should match two requirements.
 Both of these requirements are taking place in [conf.d/cmake/config.cmake](conf.d/cmake/config.cmake).
 
-* **Project name**
-Your project name should match your package name.
-Here for example in the agl-helloworld-service config.cmake, we can see:
-`set(PROJECT_NAME agl-service-helloworld)`
-Thus the package must be named `agl-service-helloworld`.
+- **Project name**
+  Your project name should match your package name.
+  Here for example in the agl-helloworld-service config.cmake, we can see:
+  `set(PROJECT_NAME agl-service-helloworld)`
+  Thus the package must be named `agl-service-helloworld`.
 
-* **Project version**
-For convenience, we advise you not to set the project version in the config.cmake.
-~~`set(PROJECT_VERSION "1.0")`~~
-By doing so, your project version will automatically be set to the version listed in the specfile.
-This tweak allows afm macros to be fully effective regarding your widget management once deployed on a board.
+- **Project version**
+  For convenience, we advise you not to set the project version in the config.cmake.
+  ~~`set(PROJECT_VERSION "1.0")`~~
+  By doing so, your project version will automatically be set to the version listed in the specfile.
+  This tweak allows afm macros to be fully effective regarding your widget management once deployed on a board.
 
 ## Deploy on a board
 
@@ -61,9 +61,9 @@ Now that an agl-service-helloworld package have been generated thanks to redpesk
 Since redpesk® support cross-compilation, we can use either a x86_64 or aarch64 board to get your package installed in.
 During this part, two cases will be studied:
 
-* Emulated x86_64 board: **qemu-x86_64**
+- Emulated x86_64 board: **qemu-x86_64**
 
-* Real aarch64 board: **m3ulcb**
+- Real aarch64 board: **m3ulcb**
 
 If you want to use the agl-helloworld-service in an embedded aarch64 context, but do not have a real board, an other tutorial is present in the repository that you can find at the following [path](docs/qemu-aarch64.md).
 
@@ -71,31 +71,31 @@ If you want to use the agl-helloworld-service in an embedded aarch64 context, bu
 
 Download the latest redpesk® image according to your board architecture.
 
-* **qemu-x86_64**
+- **qemu-x86_64**
 
 ```bash
 export RP_IMAGE=RedPesk-minimal-8_II-1.x86_64.raw.xz
-wget https://download.redpesk.bzh/redpesk/releases/8/images/minimal/x86_64/latest/$RP_IMAGE
+wget https://download.redpesk.bzh/redpesk-devel/releases/28/images/minimal/x86_64/$RP_IMAGE
 ```
 
-* **m3ulcb**
+- **m3ulcb**
 
 ```bash
 export RP_IMAGE=RedPesk-minimal-8_II-1.aarch64.raw.xz
-wget https://download.redpesk.bzh/redpesk/releases/8/images/minimal/aarch64/latest/$RP_IMAGE
+wget https://download.redpesk.bzh/redpesk-devel/releases/28/images/minimal/aarch64/latest/$RP_IMAGE
 ```
 
 The image you have just downloaded has the following configuration:
 
-* login: root
+- login: root
 
-* password: root
+- password: root
 
 ### Running a redpesk® image
 
 Here we are, you are about to run the redpesk® image. This section will deal with both types of image: x86_64 & aarch64.
 
-* **qemu-x86_64**
+- **qemu-x86_64**
 
 First of all unzip the archive you have just downloaded to retrieve the redpesk® image.
 
@@ -135,7 +135,7 @@ You can access your emulated board with the following command:
 ssh root@localhost -p ${TCP_PORT}
 ```
 
-* **m3ulcb**
+- **m3ulcb**
 
 The aim of this part is to flash the redpesk® raw image on a SDCard. To do so, bmaptools will be used. For example, ubuntu user can run:
 
@@ -145,9 +145,9 @@ sudo apt-get install bmap-tools
 
 Then insert your SDCard and retrieve its device name. To do so you can execute the following command:
 
- ```bash
+```bash
 lsblk -dli -o NAME,TYPE,HOTPLUG | grep "disk.*1$"
- ```
+```
 
 Then export it into the environment variable DEVICE, for example:
 
@@ -161,7 +161,7 @@ If the SDCard is mounted, umount it.
 sudo unmount ${DEVICE}
 ```
 
-Now  write the image onto the SDCard.
+Now write the image onto the SDCard.
 
 ```bash
 sudo bmaptool copy ${RP_IMAGE} ${DEVICE}
@@ -179,40 +179,59 @@ ssh root@${YOUR_BOARD_IP}
 There are no difference in the command related to your package installation, neither in a x86_64, nor in an aarch64 redpesk® distribution.
 
 Once you get in your redpesk® image, you can proceed to the package installation.
-As a reminder, the agl-helloworld-service gathered two sub-package the **agl-service-helloworld-widget** and the **agl-service-helloworld-widget-test**.
+As a reminder, the agl-helloworld-service gathered two sub-package the **agl-service-helloworld** and the **agl-service-helloworld-test**.
 To install the widget sub-package, you can simply run
 
 ```bash
-dnf install agl-service-helloworld-widget
+dnf install agl-service-helloworld
 ```
 
 If you correctly set your project name and version as explained in the **Build** part, you should have the following output during the package installation
 
- ```bash
-[root@localhost ~] dnf install agl-service-helloworld-widget
-INFO:  agl-service-helloworld installation
-INFO:  agl-service-helloworld start
-INFO:  agl-service-helloworld port is ${PORT}
- ```
+```bash
+[root@localhost ~] dnf install agl-service-helloworld
+NOTICE: -- Install redpesk widget from /var/local/lib/afm/applications/agl-service-helloworld --
+```
 
 This implies that your widget has been installed correctly.
+
+Check if your widget id is `agl-service-helloworld`.
+
+```bash
+afm-util list --all
+[
+  {
+    "description":"Provide an AGL Helloworld Binding",
+    "name":"agl-service-helloworld",
+    "shortname":"",
+    "id":"agl-service-helloworld",
+    "version":"8.99",
+    "author":"Iot-Team <frederic.marec@iot.bzh>",
+    "author-email":"",
+    "width":"",
+    "height":"",
+    "icon":"/var/local/lib/afm/applications/agl-service-helloworld/icon.png",
+    "http-port":30001
+  }
+]
+```
 
 You can then start the service by running:
 
 ```bash
-[root@localhost ~] afm-util start agl-service-helloworld@0.0
+[root@localhost ~] afm-util start agl-service-helloworld
 8628
 ```
 
 For example, you can access to its verb **ping** which belong to its api **helloworld** thanks to a HTTP or websocket request sent to the port `$PORT` such as follow
 
-* HTTP request:
+- HTTP request:
 
 ```bash
 curl -H "Content-Type: application/json" http://localhost:${PORT}/api/helloworld/ping | jq
 ```
 
-* Websocket request:
+- Websocket request:
 
 ```bash
 afb-client-demo -H ws://localhost:${PORT}/api?token=x\&uuid=magic helloworld ping
@@ -235,7 +254,7 @@ ON-REPLY 1:helloworld/ping: OK
 Once again, if you correctly set your project name and version as explained in the **Build** part, to correctly stop and remove your widget, simply run
 
 ```bash
-dnf remove agl-service-helloworld-widget
+dnf remove agl-service-helloworld
 ```
 
 You should have the following output
@@ -250,31 +269,38 @@ INFO:  uninstall agl-service-helloworld
 
 As explained before, the agl-helloworld service package contained a test sub-package.
 This package implements a set of function meant to test the agl-service-helloworld-widget functionalities.
-First of all ensure you installed the **agl-service-helloworld-widget**. Then proceed to the test related package installation.
+First of all ensure you installed the **agl-service-helloworld**. Then proceed to the test related package installation.
 
 ```bash
-dnf install agl-service-helloworld-widget-test
+dnf install agl-service-helloworld-test
 ```
 
 If you correctly set your project name and version as explained in the Build part, the test widget should be installed in your target.
 Keep in mind that to launch tests, the core widget needs to be installed and **currently running** on the target.
 
- ```bash
-[root@localhost ~] dnf install agl-service-helloworld-widget-test
+```bash
+[root@localhost ~] dnf install agl-service-helloworld-test
 INFO:  agl-service-helloworld-test installation
- ```
+```
 
-Now that the test sub-package has been installed, its widget is stored in the following directory: `/usr/AGL`.
-In order to launch the test, you must run the following command
+Now that the test sub-package has been installed.
+
+Check if the widget id is `agl-service-helloworld-test`.
 
 ```bash
-afm-test /usr/AGL/agl-service-helloworld-test.wgt
+afm-util list --all
+```
+
+In order to launch the test, you must run the following command passing the widget id.
+
+```bash
+afm-test agl-service-helloworld-test
 ```
 
 Then a prompt appears in TAP format, describing which test is currently running and whether it succeed or failed.
 
 ```bash
-[root@localhost ~] afm-test /usr/AGL/agl-service-helloworld-test.wgt
+[root@localhost ~] afm-test agl-service-helloworld-test
 1..6
 # Started on Wed Mar 11 09:42:52 2020
 # Starting class: testPingSuccess

--- a/conf.d/packaging/agl-service-helloworld.spec
+++ b/conf.d/packaging/agl-service-helloworld.spec
@@ -13,12 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###########################################################################
-
-%define debug_package %{nil}
-
 Name:    agl-service-helloworld
+#Hexsha: cde438aed1e990b69d4ed2fb3aa3b4ba22e78a6a
 Version: 8.99.6
-Release: 8%{?dist}
+Release: 12%{?dist}
 License: APL2.0
 Summary: helloworld agl service set to be used in redpesk
 URL:     https://github.com/redpesk/agl-service-helloworld
@@ -39,28 +37,38 @@ The helloworld agl service gathers two bindings.
 - helloworld-skeleton: Increment a counter
 - helloworld-subscribe-event: Subscribe and get notified whether an event is emited
 
-%afm_package_widget
-%afm_package_widget_test
-%afm_package_widget_redtest
+# main package: default install widget in /var/local/lib/afm/applications/%%{name}
+%afm_package
+# test package: default install widget in /var/local/lib/afm/applications/%%{name}-test
+%afm_package_test
+%afm_package_redtest
 
 %prep
 %autosetup -p 1
 
 %build
-%afm_configure_cmake_release
+%afm_configure_cmake
 %afm_build_cmake
-%afm_widget
 
 %install
-%afm_install_widget
-%afm_install_widgettest
-%afm_install_widgetredtest
+%afm_makeinstall
+%afm_install_redtest
 
 %check
 
 %clean
 
 %changelog
+
+* Mon May 18 2020 IoT.bzh(iotpkg) <redpesk.list@iot.bzh> gcde438ae
+- Upgrade version from source commit sha: cde438aed1e990b69d4ed2fb3aa3b4ba22e78a6a
+- Commit message:
+- 	Correction inside the run-redtest script (#3)
+-
+
+* Mon May 18 2020 IoT.bzh <clement.benier@iot.bzh> 8.99.6
+- bump version of afm-rpm-macros
+
 * Wed Apr 29 2020 IoT.bzh <redpesk.list.iot.bzh> 8.99.6
 - Modifications in order to add a redtest subpackage
 
@@ -69,3 +77,4 @@ The helloworld agl service gathers two bindings.
 
 * Fri Feb 14 2020 IoT.bzh <redpesk.list.iot.bzh> 8.99.5
 - Creation of the spec file from RedPesk generator
+


### PR DESCRIPTION
- do not use afm-util install to install rpm
- use redpesk rpm plugin for security rules

Change-Id: I59dba3d4a9a975c66b07b6d4a510c50c51dcee88
Signed-off-by: Clément Bénier <clement.benier@iot.bzh>