### PR TITLE
[Redtest] Add a template version for run-redtest

### DIFF
--- a/conf.d/packaging/agl-service-helloworld.spec
+++ b/conf.d/packaging/agl-service-helloworld.spec
@@ -16,7 +16,7 @@
 Name:    agl-service-helloworld
 #Hexsha: cde438aed1e990b69d4ed2fb3aa3b4ba22e78a6a
 Version: 8.99.6
-Release: 12%{?dist}
+Release: 13%{?dist}
 License: APL2.0
 Summary: helloworld agl service set to be used in redpesk
 URL:     https://github.com/redpesk/agl-service-helloworld
@@ -52,13 +52,14 @@ The helloworld agl service gathers two bindings.
 
 %install
 %afm_makeinstall
-%afm_install_redtest
 
 %check
 
 %clean
 
 %changelog
+* Wed Jun 24 2020 IoT.bzh <armand.beneteau.iot.bzh> 8.99.6
+- Add the use of cmake template for run-redtest
 
 * Mon May 18 2020 IoT.bzh(iotpkg) <redpesk.list@iot.bzh> gcde438ae
 - Upgrade version from source commit sha: cde438aed1e990b69d4ed2fb3aa3b4ba22e78a6a

--- a/redtest/CMakeLists.txt
+++ b/redtest/CMakeLists.txt
@@ -20,5 +20,5 @@ set(PACKAGE_REDTEST "agl-service-helloworld-redtest")
 
 configure_file(run-redtest.in run-redtest @ONLY)
 
-install(FILES ${CMAKE_BINARY_DIR}/run-redtest DESTINATION /usr/lib/${PACKAGE_REDTEST}/redtest)
+install(FILES ${CMAKE_BINARY_DIR}/redtest/run-redtest DESTINATION /usr/lib/${PACKAGE_REDTEST}/redtest)
 

--- a/redtest/CMakeLists.txt
+++ b/redtest/CMakeLists.txt
@@ -20,5 +20,6 @@ set(PACKAGE_REDTEST "agl-service-helloworld-redtest")
 
 configure_file(run-redtest.in run-redtest @ONLY)
 
-install(FILES ${CMAKE_BINARY_DIR}/redtest/run-redtest DESTINATION /usr/lib/${PACKAGE_REDTEST}/redtest)
+install(PROGRAMS ${CMAKE_BINARY_DIR}/redtest/run-redtest
+	DESTINATION /usr/lib/${PACKAGE_REDTEST}/redtest)
 

--- a/redtest/CMakeLists.txt
+++ b/redtest/CMakeLists.txt
@@ -20,5 +20,5 @@ set(PACKAGE_REDTEST "agl-service-helloworld-redtest")
 
 configure_file(run-redtest.in run-redtest @ONLY)
 
-install(FILES run-redtest DESTINATION /usr/lib/${PACKAGE_REDTEST}/redtest)
+install(FILES ${CMAKE_BINARY_DIR}/run-redtest DESTINATION /usr/lib/${PACKAGE_REDTEST}/redtest)
 

--- a/redtest/CMakeLists.txt
+++ b/redtest/CMakeLists.txt
@@ -20,3 +20,5 @@ set(PACKAGE_REDTEST "agl-service-helloworld-redtest")
 
 configure_file(run-redtest.in run-redtest @ONLY)
 
+install(FILES run-redtest DESTINATION /usr/lib/${PACKAGE_REDTEST}/redtest)
+

--- a/redtest/CMakeLists.txt
+++ b/redtest/CMakeLists.txt
@@ -1,0 +1,22 @@
+###########################################################################
+# Copyright 2015 - 2020 IoT.bzh
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###########################################################################
+
+set(BINDING_NAME "agl-service-helloworld")
+set(BINDING_TEST_NAME "agl-service-helloworld-test")
+set(PACKAGE_REDTEST "agl-service-helloworld-redtest")
+
+configure_file(run-redtest.in run-redtest @ONLY)
+

--- a/redtest/run-redtest.in
+++ b/redtest/run-redtest.in
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-PACKAGE_REDTEST_NAME="agl-service-helloworld-redtest"
-BINDING_NAME="agl-service-helloworld"
-BINDING_TEST_NAME="agl-service-helloworld-test"
+PACKAGE_REDTEST_NAME="@PACKAGE_REDTEST@"
+BINDING_NAME="@BINDING_NAME@"
+BINDING_TEST_NAME="@BINDING_TEST_NAME@"
 AFB_TEST_BINDER="afbtest"
 
 # Get the name of the test binder


### PR DESCRIPTION
This commit create a cmake template for run-redtest. This template is
named run-redtest.in and allows the future users to easily create their
own.

In order to do so, they have just to copy this template and to
modify the variable defined in the CMakeLists.txt file adjacent to the
template.

Signed-off-by: Armand BENETEAU <armand.beneteau@iot.bzh>